### PR TITLE
Slice 4: turn loop, AI (medium), wind, Controller split

### DIFF
--- a/src/tanks/ai.py
+++ b/src/tanks/ai.py
@@ -1,0 +1,96 @@
+import math
+import random
+from dataclasses import dataclass
+
+from . import config as C
+
+
+@dataclass(frozen=True)
+class DifficultyCfg:
+    angle_sigma_deg: float
+    power_sigma_frac: float
+    wind_aware: bool
+    memory: bool
+
+
+DIFFICULTY: dict[str, DifficultyCfg] = {
+    "easy":   DifficultyCfg(angle_sigma_deg=15.0, power_sigma_frac=0.20, wind_aware=False, memory=False),
+    "medium": DifficultyCfg(angle_sigma_deg=5.0,  power_sigma_frac=0.08, wind_aware=False, memory=True),
+    "hard":   DifficultyCfg(angle_sigma_deg=1.0,  power_sigma_frac=0.02, wind_aware=True,  memory=True),
+}
+
+
+def solve_angle(
+    horiz_dist: float,
+    dy: float,
+    v: float,
+    g: float = C.GRAVITY,
+    prefer_high: bool = False,
+) -> float | None:
+    """Solve launch angle (radians, above horizontal in shooter's facing direction).
+
+    horiz_dist: positive horizontal distance to target.
+    dy: vertical offset, pygame coords (positive = target is below shooter).
+    v: launch speed.
+    g: gravity (positive, pulls down).
+    Returns angle in radians, or None if target is unreachable at this speed.
+    """
+    if horiz_dist <= 0 or v <= 0 or g <= 0:
+        return None
+    H = horiz_dist
+    discriminant = v**4 - (g * H) ** 2 + 2 * g * v**2 * dy
+    if discriminant < 0:
+        return None
+    s = math.sqrt(discriminant)
+    u = (v * v + (s if prefer_high else -s)) / (g * H)
+    return math.atan(u)
+
+
+def pick_power(horiz_dist: float, dy: float, g: float = C.GRAVITY) -> float:
+    """Choose a launch power that comfortably reaches a target at this distance."""
+    H = max(horiz_dist, 1.0)
+    v_min_flat = math.sqrt(g * H)  # minimum v to reach H on flat ground at 45°
+    return max(C.POWER_MIN, min(C.POWER_MAX, v_min_flat * 1.2))
+
+
+def plan_shot(
+    shooter_xy: tuple[float, float],
+    target_xy: tuple[float, float],
+    gravity: float,
+    wind: float,
+    cfg: DifficultyCfg,
+    last_offset_x: float,
+    rng: random.Random,
+) -> tuple[float, float]:
+    """Pick the (angle_deg, power) the AI will fire with.
+
+    Returns angle in degrees in the game's [0, 180] convention (0 = horizontal in
+    shooter's facing direction; 90 = straight up; 180 = horizontal opposite).
+    """
+    sx, _sy = shooter_xy
+    tx, ty = target_xy
+    if cfg.memory:
+        tx -= 0.6 * last_offset_x
+
+    horiz = abs(tx - sx)
+    dy = ty - shooter_xy[1]
+
+    v = pick_power(horiz, dy, gravity)
+    angle_rad = solve_angle(horiz, dy, v, gravity, prefer_high=False)
+    if angle_rad is None:
+        angle_rad = math.radians(45.0)  # max-range fallback for flat ground
+
+    if cfg.wind_aware:
+        # Crude compensation: bias barrel into the wind. Negative sign because
+        # wind > 0 pushes the shell rightward, so left-facing tanks need the
+        # opposite correction; the magnitude was tuned by feel.
+        facing_sign = 1.0 if (tx - sx) >= 0 else -1.0
+        angle_rad -= facing_sign * wind * 0.0015
+
+    angle_rad += math.radians(rng.gauss(0.0, cfg.angle_sigma_deg))
+    v *= 1.0 + rng.gauss(0.0, cfg.power_sigma_frac)
+
+    angle_deg = math.degrees(angle_rad)
+    angle_deg = max(C.ANGLE_MIN, min(C.ANGLE_MAX, angle_deg))
+    v = max(C.POWER_MIN, min(C.POWER_MAX, v))
+    return (angle_deg, v)

--- a/src/tanks/config.py
+++ b/src/tanks/config.py
@@ -26,11 +26,15 @@ TANK_BARREL_W = 4
 DEFAULT_ANGLE_DEG = 60.0
 
 GRAVITY = 400.0
+WIND_RANGE = (-50.0, 50.0)  # px/s² horizontal, randomized per round
 POWER_MIN = 100.0
 POWER_MAX = 800.0
 DEFAULT_POWER = 400.0
 ANGLE_MIN = 0.0
 ANGLE_MAX = 180.0
+
+AI_TURN_DELAY = 0.8  # seconds AI takes between turn-start and firing
+AI_DEFAULT_DIFFICULTY = "medium"
 
 ANGLE_RATE_DEG_PER_SEC = 60.0
 POWER_RATE_PER_SEC = 300.0

--- a/src/tanks/controller.py
+++ b/src/tanks/controller.py
@@ -1,0 +1,138 @@
+import random
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pygame
+
+from . import ai
+from . import config as C
+
+if TYPE_CHECKING:
+    from .tank import Tank
+    from .terrain import Terrain
+
+
+@dataclass
+class World:
+    terrain: "Terrain"
+    wind: float
+    gravity: float
+    tanks: list["Tank"]
+
+
+def _clamp(v: float, lo: float, hi: float) -> float:
+    if v < lo:
+        return lo
+    if v > hi:
+        return hi
+    return v
+
+
+class Controller(ABC):
+    """Drives a tank during its turn. Mutates `tank.angle_deg` / `tank.power` directly."""
+
+    def begin_turn(self, tank: "Tank", world: World) -> None:  # noqa: B027
+        return
+
+    def end_turn(self, tank: "Tank", world: World, landing_x: float | None) -> None:  # noqa: B027
+        return
+
+    @abstractmethod
+    def tick(
+        self,
+        tank: "Tank",
+        world: World,
+        dt: float,
+        events: list[pygame.event.Event],
+    ) -> bool:
+        """Per-frame update. Returns True if the tank fires this tick."""
+        ...
+
+
+class PlayerController(Controller):
+    def tick(self, tank, world, dt, events):
+        keys = pygame.key.get_pressed()
+        if keys[pygame.K_LEFT]:
+            tank.angle_deg = _clamp(
+                tank.angle_deg + C.ANGLE_RATE_DEG_PER_SEC * dt, C.ANGLE_MIN, C.ANGLE_MAX
+            )
+        if keys[pygame.K_RIGHT]:
+            tank.angle_deg = _clamp(
+                tank.angle_deg - C.ANGLE_RATE_DEG_PER_SEC * dt, C.ANGLE_MIN, C.ANGLE_MAX
+            )
+        if keys[pygame.K_UP]:
+            tank.power = _clamp(
+                tank.power + C.POWER_RATE_PER_SEC * dt, C.POWER_MIN, C.POWER_MAX
+            )
+        if keys[pygame.K_DOWN]:
+            tank.power = _clamp(
+                tank.power - C.POWER_RATE_PER_SEC * dt, C.POWER_MIN, C.POWER_MAX
+            )
+        for ev in events:
+            if ev.type == pygame.KEYDOWN and ev.key == pygame.K_SPACE:
+                return True
+        return False
+
+
+class AIController(Controller):
+    def __init__(
+        self,
+        difficulty: str = C.AI_DEFAULT_DIFFICULTY,
+        rng: random.Random | None = None,
+        delay: float = C.AI_TURN_DELAY,
+    ) -> None:
+        self.cfg = ai.DIFFICULTY[difficulty]
+        self.rng = rng or random.Random()
+        self.delay = delay
+        self.last_offset_x = 0.0
+        self._target_angle: float | None = None
+        self._target_power: float | None = None
+        self._timer = 0.0
+        self._armed = False
+        self._fired = False
+
+    def begin_turn(self, tank, world):
+        opponent = next((t for t in world.tanks if t is not tank and t.alive), None)
+        if opponent is None:
+            self._target_angle = tank.angle_deg
+            self._target_power = tank.power
+        else:
+            angle_deg, power = ai.plan_shot(
+                shooter_xy=(float(tank.x), float(tank.y)),
+                target_xy=opponent.body_center(),
+                gravity=world.gravity,
+                wind=world.wind,
+                cfg=self.cfg,
+                last_offset_x=self.last_offset_x,
+                rng=self.rng,
+            )
+            self._target_angle = angle_deg
+            self._target_power = power
+        self._timer = 0.0
+        self._armed = False
+        self._fired = False
+
+    def tick(self, tank, world, dt, events):
+        self._timer += dt
+        # Telegraph: snap to target ~halfway through the delay so the player
+        # can see what the AI is aiming at before the shot.
+        if not self._armed and self._timer >= self.delay * 0.4:
+            if self._target_angle is not None:
+                tank.angle_deg = self._target_angle
+            if self._target_power is not None:
+                tank.power = self._target_power
+            self._armed = True
+        if self._armed and not self._fired and self._timer >= self.delay:
+            self._fired = True
+            return True
+        return False
+
+    def end_turn(self, tank, world, landing_x):
+        if landing_x is None or not self.cfg.memory:
+            return
+        opponent = next((t for t in world.tanks if t is not tank), None)
+        if opponent is None:
+            return
+        target_x, _ = opponent.body_center()
+        self.last_offset_x = landing_x - target_x

--- a/src/tanks/game.py
+++ b/src/tanks/game.py
@@ -3,24 +3,23 @@ import random
 import pygame
 
 from . import config as C
+from .controller import AIController, PlayerController, World
 from .projectile import Projectile, damage_at
 from .tank import Tank
 from .terrain import Terrain
 
-STATE_PLAYING = "playing"
+STATE_PLAYER_TURN = "player_turn"
+STATE_AI_TURN = "ai_turn"
+STATE_FLIGHT = "flight"
 STATE_ROUND_OVER = "round_over"
 
 
-def _clamp(v: float, lo: float, hi: float) -> float:
-    if v < lo:
-        return lo
-    if v > hi:
-        return hi
-    return v
-
-
 class Game:
-    def __init__(self, seed: int | None = None) -> None:
+    def __init__(
+        self,
+        seed: int | None = None,
+        ai_difficulty: str = C.AI_DEFAULT_DIFFICULTY,
+    ) -> None:
         pygame.init()
         pygame.font.init()
         pygame.display.set_caption("Tank Game")
@@ -28,15 +27,48 @@ class Game:
         self.clock = pygame.time.Clock()
         self.font = pygame.font.SysFont(None, C.HUD_FONT_SIZE)
         self.big_font = pygame.font.SysFont(None, C.ROUND_OVER_FONT_SIZE)
+
+        self.rng = random.Random(seed)
         self.terrain = Terrain.generate(C.SCREEN_W, seed=seed)
         self.player = Tank(x=C.PLAYER_X, color=C.PLAYER_COLOR, facing=+1)
         self.ai = Tank(x=C.AI_X, color=C.AI_COLOR, facing=-1)
-        for t in (self.player, self.ai):
+        self.tanks: list[Tank] = [self.player, self.ai]
+        for t in self.tanks:
             t.seat(self.terrain)
+
+        self.player_ctrl = PlayerController()
+        self.ai_ctrl = AIController(
+            difficulty=ai_difficulty,
+            rng=random.Random(self.rng.randint(0, 1_000_000)),
+        )
+
+        self.wind = self._roll_wind()
         self.flying: Projectile | None = None
-        self.state = STATE_PLAYING
+        self.current_tank: Tank = self.player
+        self.next_tank: Tank | None = None
+        self.state = STATE_PLAYER_TURN
         self.round_over_msg = ""
+        self._frame_events: list[pygame.event.Event] = []
         self.running = True
+
+        self._controller_for(self.current_tank).begin_turn(
+            self.current_tank, self._world()
+        )
+
+    def _controller_for(self, tank: Tank):
+        return self.player_ctrl if tank is self.player else self.ai_ctrl
+
+    def _world(self) -> World:
+        return World(
+            terrain=self.terrain,
+            wind=self.wind,
+            gravity=C.GRAVITY,
+            tanks=self.tanks,
+        )
+
+    def _roll_wind(self) -> float:
+        lo, hi = C.WIND_RANGE
+        return self.rng.uniform(lo, hi)
 
     def run(self) -> None:
         while self.running:
@@ -47,49 +79,80 @@ class Game:
         pygame.quit()
 
     def _handle_events(self) -> None:
-        for event in pygame.event.get():
+        events = pygame.event.get()
+        for event in events:
             if event.type == pygame.QUIT:
                 self.running = False
             elif event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_ESCAPE:
                     self.running = False
-                elif self.state == STATE_PLAYING:
-                    if event.key == pygame.K_SPACE and self.flying is None:
-                        self._fire(self.player)
-                elif self.state == STATE_ROUND_OVER:
-                    if event.key == pygame.K_r:
-                        self._reset_round()
+                elif event.key == pygame.K_r and self.state == STATE_ROUND_OVER:
+                    self._reset_round()
+        self._frame_events = events
 
     def _update(self, dt: float) -> None:
-        if self.state == STATE_ROUND_OVER:
-            return
-        if self.flying is None:
-            self._read_aim_keys(self.player, dt)
-        else:
-            self.flying.update(dt)
+        if self.state in (STATE_PLAYER_TURN, STATE_AI_TURN):
+            ctrl = self._controller_for(self.current_tank)
+            fired = ctrl.tick(
+                self.current_tank, self._world(), dt, self._frame_events
+            )
+            if fired:
+                self._fire(self.current_tank)
+                self.next_tank = self._other(self.current_tank)
+                self.state = STATE_FLIGHT
+        elif self.state == STATE_FLIGHT and self.flying is not None:
+            self.flying.update(dt, gravity=C.GRAVITY, wind=self.wind)
             if self.flying.hit_terrain(self.terrain):
                 self._on_impact(self.flying.x, self.flying.y)
-                self.flying = None
             elif self.flying.off_screen(C.SCREEN_W, C.SCREEN_H):
-                self.flying = None
+                self._end_flight(landing_x=None)
+
+    def _other(self, tank: Tank) -> Tank:
+        return self.ai if tank is self.player else self.player
+
+    def _fire(self, tank: Tank) -> None:
+        tip_x, tip_y = tank.barrel_tip()
+        self.flying = Projectile.fired_from(
+            tip_x, tip_y, tank.angle_deg, tank.power, tank.facing
+        )
 
     def _on_impact(self, x: float, y: float) -> None:
         self.terrain.apply_crater(int(x), y, C.EXPLOSION_RADIUS)
         impact = (x, y)
-        for t in (self.player, self.ai):
+        for t in self.tanks:
             if not t.alive:
                 continue
             dmg = damage_at(impact, t.body_center())
             if dmg > 0:
                 t.take_damage(dmg)
-        for t in (self.player, self.ai):
+        for t in self.tanks:
             t.seat(self.terrain)
         print(
-            f"BOOM at ({int(x)},{int(y)})  "
+            f"BOOM at ({int(x)},{int(y)})  wind={self.wind:+.0f}  "
             f"player_hp={self.player.hp} ai_hp={self.ai.hp}"
         )
         if not self.player.alive or not self.ai.alive:
+            self._end_flight(landing_x=x, dying=True)
             self._enter_round_over()
+            return
+        self._end_flight(landing_x=x)
+
+    def _end_flight(self, landing_x: float | None, dying: bool = False) -> None:
+        self._controller_for(self.current_tank).end_turn(
+            self.current_tank, self._world(), landing_x
+        )
+        self.flying = None
+        if dying:
+            return
+        nxt = self.next_tank or self._other(self.current_tank)
+        self.current_tank = nxt
+        self.next_tank = None
+        self.state = (
+            STATE_PLAYER_TURN if self.current_tank is self.player else STATE_AI_TURN
+        )
+        self._controller_for(self.current_tank).begin_turn(
+            self.current_tank, self._world()
+        )
 
     def _enter_round_over(self) -> None:
         if not self.player.alive and not self.ai.alive:
@@ -101,46 +164,27 @@ class Game:
         self.state = STATE_ROUND_OVER
 
     def _reset_round(self) -> None:
-        self.terrain = Terrain.generate(
-            C.SCREEN_W, seed=random.randint(0, 1_000_000)
-        )
-        for t in (self.player, self.ai):
+        new_seed = self.rng.randint(0, 1_000_000)
+        self.terrain = Terrain.generate(C.SCREEN_W, seed=new_seed)
+        for t in self.tanks:
             t.hp = C.TANK_HP
             t.seat(self.terrain)
+        self.wind = self._roll_wind()
         self.flying = None
-        self.state = STATE_PLAYING
+        self.current_tank = self.player
+        self.next_tank = None
+        self.state = STATE_PLAYER_TURN
         self.round_over_msg = ""
-
-    def _read_aim_keys(self, tank: Tank, dt: float) -> None:
-        keys = pygame.key.get_pressed()
-        if keys[pygame.K_LEFT]:
-            tank.angle_deg = _clamp(
-                tank.angle_deg + C.ANGLE_RATE_DEG_PER_SEC * dt, C.ANGLE_MIN, C.ANGLE_MAX
-            )
-        if keys[pygame.K_RIGHT]:
-            tank.angle_deg = _clamp(
-                tank.angle_deg - C.ANGLE_RATE_DEG_PER_SEC * dt, C.ANGLE_MIN, C.ANGLE_MAX
-            )
-        if keys[pygame.K_UP]:
-            tank.power = _clamp(
-                tank.power + C.POWER_RATE_PER_SEC * dt, C.POWER_MIN, C.POWER_MAX
-            )
-        if keys[pygame.K_DOWN]:
-            tank.power = _clamp(
-                tank.power - C.POWER_RATE_PER_SEC * dt, C.POWER_MIN, C.POWER_MAX
-            )
-
-    def _fire(self, tank: Tank) -> None:
-        tip_x, tip_y = tank.barrel_tip()
-        self.flying = Projectile.fired_from(
-            tip_x, tip_y, tank.angle_deg, tank.power, tank.facing
+        self.ai_ctrl.last_offset_x = 0.0
+        self._controller_for(self.current_tank).begin_turn(
+            self.current_tank, self._world()
         )
 
     def _render(self) -> None:
         self.screen.fill(C.SKY_COLOR)
         self.terrain.render(self.screen)
-        self.player.render(self.screen)
-        self.ai.render(self.screen)
+        for t in self.tanks:
+            t.render(self.screen)
         if self.flying is not None:
             self.flying.render(self.screen)
         self._render_hud()
@@ -149,17 +193,40 @@ class Game:
         pygame.display.flip()
 
     def _render_hud(self) -> None:
-        if self.state == STATE_ROUND_OVER:
-            return
-        status = "FIRING" if self.flying is not None else "READY"
-        line = (
-            f"ANGLE {self.player.angle_deg:5.1f}    "
-            f"POWER {self.player.power:5.0f}    "
-            f"{status}"
-        )
-        color = C.HUD_DIM_COLOR if self.flying is not None else C.HUD_COLOR
-        surf = self.font.render(line, True, color)
-        self.screen.blit(surf, (10, 8))
+        if self.state == STATE_PLAYER_TURN:
+            left = (
+                f"YOU   ANGLE {self.player.angle_deg:5.1f}   "
+                f"POWER {self.player.power:5.0f}"
+            )
+            color = C.HUD_COLOR
+        elif self.state == STATE_AI_TURN:
+            left = "AI THINKING..."
+            color = C.HUD_DIM_COLOR
+        elif self.state == STATE_FLIGHT:
+            who = "YOU" if self.current_tank is self.player else "AI"
+            left = f"{who} fired"
+            color = C.HUD_DIM_COLOR
+        else:
+            left = ""
+            color = C.HUD_COLOR
+        if left:
+            surf = self.font.render(left, True, color)
+            self.screen.blit(surf, (10, 8))
+        wind_str = self._wind_string()
+        wind_surf = self.font.render(wind_str, True, C.HUD_COLOR)
+        wind_rect = wind_surf.get_rect()
+        wind_rect.topright = (C.SCREEN_W - 10, 8)
+        self.screen.blit(wind_surf, wind_rect)
+
+    def _wind_string(self) -> str:
+        mag = abs(self.wind)
+        if mag < 1.0:
+            return "WIND --- 0"
+        arrow = ">" if self.wind > 0 else "<"
+        bars = arrow * max(1, min(5, int(mag / 10) + 1))
+        if self.wind > 0:
+            return f"WIND {bars} {self.wind:+.0f}"
+        return f"WIND {bars} {self.wind:+.0f}"
 
     def _render_round_over(self) -> None:
         msg = f"ROUND OVER — {self.round_over_msg}"

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,124 @@
+import math
+import random
+
+import pytest
+
+from tanks import config as C
+from tanks.ai import DIFFICULTY, DifficultyCfg, plan_shot, solve_angle
+from tanks.projectile import Projectile
+
+
+def _simulate(angle_rad: float, v: float, g: float, max_x: float, dt: float = 1 / 240) -> Projectile:
+    p = Projectile(0.0, 0.0, v * math.cos(angle_rad), -v * math.sin(angle_rad))
+    while p.x < max_x and p.y < 5000:
+        p.update(dt=dt, gravity=g, wind=0.0)
+        if p.y > 5000:
+            break
+    return p
+
+
+def test_solve_angle_unreachable_returns_none():
+    # A very far target with a weak velocity: out of range
+    assert solve_angle(horiz_dist=10_000, dy=0.0, v=100.0, g=400.0) is None
+
+
+def test_solve_angle_low_arc_lands_near_target():
+    H, dy, v, g = 500.0, 0.0, 500.0, 400.0
+    ang = solve_angle(H, dy, v, g, prefer_high=False)
+    assert ang is not None
+    assert 0 < ang < math.radians(45.0) + 0.1  # low arc is shallow
+
+    p = _simulate(ang, v, g, max_x=H)
+    assert abs(p.x - H) < 5
+    assert abs(p.y - dy) < 5
+
+
+def test_solve_angle_high_arc_lobs_higher_than_low():
+    H, dy, v, g = 500.0, 0.0, 500.0, 400.0
+    ang_low = solve_angle(H, dy, v, g, prefer_high=False)
+    ang_high = solve_angle(H, dy, v, g, prefer_high=True)
+    assert ang_low is not None and ang_high is not None
+    assert ang_high > ang_low
+
+    p = _simulate(ang_high, v, g, max_x=H)
+    assert abs(p.x - H) < 5
+    assert abs(p.y - dy) < 5
+
+
+def test_solve_angle_target_below_extends_reachable_range():
+    # Speed just shy of flat-ground max range (v_min_flat = sqrt(g·H) = 400):
+    H, v, g = 400.0, 350.0, 400.0
+    assert solve_angle(H, dy=0.0, v=v, g=g) is None
+    # ...but the same speed *can* reach a target below the shooter at the same H.
+    assert solve_angle(H, dy=300.0, v=v, g=g) is not None
+
+
+def test_difficulty_table_matches_spec():
+    assert DIFFICULTY["easy"].angle_sigma_deg == 15.0
+    assert DIFFICULTY["medium"].angle_sigma_deg == 5.0
+    assert DIFFICULTY["hard"].angle_sigma_deg == 1.0
+    assert DIFFICULTY["easy"].memory is False
+    assert DIFFICULTY["medium"].memory is True
+    assert DIFFICULTY["hard"].memory is True
+    assert DIFFICULTY["hard"].wind_aware is True
+
+
+def test_plan_shot_zero_noise_is_deterministic():
+    cfg = DifficultyCfg(angle_sigma_deg=0, power_sigma_frac=0, wind_aware=False, memory=False)
+    a1, p1 = plan_shot(
+        shooter_xy=(100, 300), target_xy=(700, 300),
+        gravity=400.0, wind=0.0, cfg=cfg, last_offset_x=0.0,
+        rng=random.Random(1),
+    )
+    a2, p2 = plan_shot(
+        shooter_xy=(100, 300), target_xy=(700, 300),
+        gravity=400.0, wind=0.0, cfg=cfg, last_offset_x=0.0,
+        rng=random.Random(99),
+    )
+    assert a1 == pytest.approx(a2)
+    assert p1 == pytest.approx(p2)
+
+
+def test_plan_shot_memory_changes_aim_when_offset_nonzero():
+    cfg_mem = DifficultyCfg(angle_sigma_deg=0, power_sigma_frac=0, wind_aware=False, memory=True)
+    cfg_nomem = DifficultyCfg(angle_sigma_deg=0, power_sigma_frac=0, wind_aware=False, memory=False)
+    args = dict(
+        shooter_xy=(100, 300), target_xy=(700, 300),
+        gravity=400.0, wind=0.0, last_offset_x=80.0,
+    )
+    a_mem, _ = plan_shot(cfg=cfg_mem, rng=random.Random(1), **args)
+    a_nomem, _ = plan_shot(cfg=cfg_nomem, rng=random.Random(1), **args)
+    assert a_mem != a_nomem
+
+
+def test_plan_shot_easy_noise_envelope_wider_than_hard():
+    args = dict(
+        shooter_xy=(100, 300), target_xy=(700, 300),
+        gravity=400.0, wind=0.0, last_offset_x=0.0,
+    )
+    rng = random.Random(0)
+    easy_angles = [
+        plan_shot(cfg=DIFFICULTY["easy"], rng=rng, **args)[0] for _ in range(200)
+    ]
+    rng = random.Random(0)
+    hard_angles = [
+        plan_shot(cfg=DIFFICULTY["hard"], rng=rng, **args)[0] for _ in range(200)
+    ]
+
+    def stddev(xs):
+        m = sum(xs) / len(xs)
+        return (sum((x - m) ** 2 for x in xs) / len(xs)) ** 0.5
+
+    assert stddev(easy_angles) > stddev(hard_angles) * 3
+
+
+def test_plan_shot_clamps_to_legal_ranges():
+    cfg = DifficultyCfg(angle_sigma_deg=200, power_sigma_frac=5.0, wind_aware=False, memory=False)
+    rng = random.Random(0)
+    for _ in range(50):
+        ang, pw = plan_shot(
+            shooter_xy=(100, 300), target_xy=(700, 300),
+            gravity=400.0, wind=0.0, cfg=cfg, last_offset_x=0.0, rng=rng,
+        )
+        assert C.ANGLE_MIN <= ang <= C.ANGLE_MAX
+        assert C.POWER_MIN <= pw <= C.POWER_MAX


### PR DESCRIPTION
Re-opened against \`main\` after #7 was auto-closed when its base branch (\`slice-3-damage-craters\`) was deleted by the squash-merge of #6. The branch was rebased cleanly onto main (slice-3's commit was detected as already-applied and skipped); same single slice-4 commit content as #7.

## Summary
- **`ai.py`** — closed-form `solve_angle` for the projectile inverse problem (returns `None` if out of range; supports low/high arc), `pick_power` heuristic, `plan_shot` that composes solver + noise + memory-correction. Difficulty table matches the spec (Easy 15° / Medium 5° / Hard 1° angle σ; memory off / on / on; wind-aware off / off / on).
- **`controller.py`** — `Controller` ABC + `World` context dataclass. `PlayerController` reads keyboard each tick. `AIController` plans on `begin_turn`, telegraphs the shot at ~40% of its 0.8s delay, fires at the end, updates `last_offset_x` in `end_turn`.
- **`game.py`** state machine: `PLAYER_TURN` ⇄ `FLIGHT` ⇄ `AI_TURN` ⇄ `FLIGHT`, → `ROUND_OVER` on death. Per-round random wind in `WIND_RANGE = (-50, 50)` is applied to every projectile; HUD shows magnitude + ASCII arrow direction.

## Test plan
- [x] \`.venv/bin/pytest tests/ -q\` — 37/37 (added 9 AI tests).
- [x] Headless full-match smoke: 30 alternating turns under medium difficulty, AI converges via memory and wins; state transitions logged correctly; reset works.
- [ ] Manual playtest.

Closes #4. Supersedes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)